### PR TITLE
Version 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Python package and application to build hadalized theme files for different
+Python package and cli application to build hadalized theme files for different
 applications.
 
 The underlying [hadalized palettes](./src/hadalized/config.py)
@@ -20,22 +20,14 @@ The builder primarily targets the neovim colorscheme files in
 [hadalized.nvim](https://github.com/shawnohare/hadalized.nvim)
 
 
-## Usage
+## Example CLI Usage
 
 Assuming `uv` is installed,
 
 ```sh
-uv run --exact hadalized`
+uv run --exact hadalized build --out="./build"
 ```
-will produce rendered theme files in `./build`.
-
-
-## Roadmap
-
-- [ ] Introduce proper cli entry point rather than simply running a function.
-  This may or may not be a separate python package utilizing `uv` workspaces.
-- [ ] Add targetted builds. For example, specify that only "neovim" themes are
-  built.
+will produce rendered theme files for all builtin applications in `./build`.
 
 
 ## Development
@@ -51,3 +43,15 @@ just check
 just test
 # commit changes
 ```
+
+## Roadmap
+
+- [x] Introduce proper cli as main entry point. (Done in v0.3 via cyclopts).
+- [x] Add targetted builds. For example, specify that only "neovim" themes are
+  built. (Done in v0.3)
+- [ ] Create example of a custom python config, e.g., for adding an app that
+  is not supported in the builtin builds.
+- [ ] (?) Allow specifying a configuration file (py or toml) to pass to cli.
+  This might imply using BaseSettings. The current setup assumes a python
+  configuration file.
+

--- a/bin/clear_cache.py
+++ b/bin/clear_cache.py
@@ -1,4 +1,0 @@
-from hadalized.cache import Cache
-
-if __name__ == "__main__":
-    Cache().clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hadalized"
-version = "0.2.2"
+version = "0.3.0"
 description = "Hadalized theme builder."
 readme = "README.md"
 authors = [
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "coloraide>=6.2",
+    "cyclopts>=4.5.0",
     "jinja2>=3.1.6",
     "loguru>=0.7.3",
     "luadata>=1.0.5",
@@ -17,7 +18,7 @@ dependencies = [
 ]
 
 [project.scripts]
-hadalized = "hadalized:writer.run"
+hadalized = "hadalized.__main__:app"
 
 [build-system]
 requires = ["uv_build>=0.9.25,<0.10.0"]

--- a/src/hadalized/__main__.py
+++ b/src/hadalized/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running hadalized cli via `python -m hadalized`."""
+
+from hadalized.cli.main import app
+
+if __name__ == "__main__":
+    app()

--- a/src/hadalized/base.py
+++ b/src/hadalized/base.py
@@ -41,13 +41,6 @@ class BaseNode(BaseModel):
         """
         return getattr(self, key.replace("-", "_"))
 
-    @property
-    def data(self) -> dict:
-        """Cached model dump."""
-        if self._dumped is None:
-            self._dumped = self.model_dump()
-        return self._dumped
-
     def model_dump_lua(self) -> str:
         """Dump the model as a lua table.
 

--- a/src/hadalized/cache.py
+++ b/src/hadalized/cache.py
@@ -18,18 +18,25 @@ class CacheDB:
 
     default_dir: ClassVar[Path] = xdg.xdg_cache_home() / "hadalized"
 
-    def __init__(self, cache_dir: Path | None = default_dir):
+    def __init__(
+        self,
+        cache_dir: Path = default_dir,
+        *,
+        in_memory: bool = False,
+    ):
         """Create a new instance.
 
         Args:
             cache_dir: Where to store the database file.
                If `None` is provided, an in-memory database
                will be used.
+            in_memory: Keyword-only argument that specifies
+               caching should take place in memory.
 
         """
-        self.cache_dir: Path = cache_dir or self.default_dir
-        self.in_memory: bool = cache_dir is None
-        self._db_file: Path = self.cache_dir / "cache.db"
+        self.cache_dir: Path = cache_dir
+        self.in_memory: bool = in_memory
+        self._db_file: Path = self.cache_dir / "builds.db"
         if not self.in_memory:
             self.cache_dir.mkdir(parents=True, exist_ok=True)
         self._conn: sqlite3.Connection
@@ -111,7 +118,7 @@ class Cache(CacheDB):
                 [str(path)],
             )
 
-    def get_hash(self, path: str | Path) -> str | None:
+    def get(self, path: str | Path) -> str | None:
         """Get a build digest for the input path.
 
         Returns:

--- a/src/hadalized/cli/__init__.py
+++ b/src/hadalized/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command line interface for hadalized theme builder."""

--- a/src/hadalized/cli/main.py
+++ b/src/hadalized/cli/main.py
@@ -1,0 +1,89 @@
+"""Application commands."""
+
+from pathlib import Path
+from typing import Annotated
+
+from cyclopts import App, Parameter
+
+from hadalized.writer import ThemeWriter
+from hadalized.config import Config
+
+app = App()
+cache_app = app.command(App(name="cache", help="Interact with the application cache."))
+
+
+# def _get_config(config: Config | None = None) -> Config:
+#     """allow this func to be monkeypatched for unit tests?"""
+#     from hadalized.config import Config
+#     return Config()
+#
+
+
+@app.command
+def build(
+    app: list[str] | None = None,
+    # TODO: filter on palettes too?
+    # palettes: Annotated[list[str] | None, Parameter(alias="-p")] = None,
+    out: Path | None = None,
+    exclude: Annotated[list[str] | None, Parameter(alias="-e")] = None,
+    verbose: Annotated[bool, Parameter(alias="-v", negative="")] = False,
+    prefix: Annotated[bool, Parameter(alias="-P", negative="")] = False,
+    config: Annotated[Config, Parameter(parse=False)] = Config(),
+):
+    """Build themes for the specified applications.
+
+    Args:
+        app: Build themes for the specified list of application names.
+            If none are provided, all theme files will be built.
+        exclude: A list of application names to exclude when building.
+        out: An output directory to copy generated theme files to.
+        verbose: Run in verbose mode.
+        prefix: If set, add each application name / theme category prefix to
+            the output path. Ignored if `out` is not specified.
+    """
+    exclude = exclude or []
+    config = config.replace(verbose=verbose)
+    if not app:
+        build_configs = list(v for k, v in config.builds.items() if k not in exclude)
+    else:
+        build_configs = [config.builds[x] for x in app if x not in exclude]
+    with ThemeWriter(config) as writer:
+        for build_config in build_configs:
+            if prefix and out is not None:
+                out /= build_config.name
+            writer.build(build_config, output_dir=out)
+
+
+# FIXME: development only
+# @app.command
+# def show(config: Config):
+#     print(config.build_dir)
+#     print(config.cache_dir is None, config.cache_dir)
+#     print(config.template_dir)
+
+
+@cache_app.command(name="clear")
+def cache_clear(
+    config: Annotated[Config, Parameter(parse=False)] = Config(),
+):
+    """Clear the application cache."""
+    from hadalized.cache import Cache
+
+    with Cache() as cache:
+        cache.clear()
+
+
+@cache_app.command(name="list", alias=["ls"])
+def cache_list(config: Config = Config()):
+    """List the contents of the application cache."""
+    with ThemeWriter(config) as writer:
+        cache = writer.cache
+        print(f"Cache db file {cache._db_file.absolute()}")
+        print(f"Cache is in memory: {cache.in_memory}.")
+        print("Cache contents")
+        results = cache._conn.execute("SELECT * from builds")
+        for path, digest in results:
+            print(f"{path}: {digest}")
+
+
+# app()

--- a/src/hadalized/cli/ruff.toml
+++ b/src/hadalized/cli/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+ignore = [
+    "FBT001",  # bool args
+    "FBT002",  # bool args
+]

--- a/src/hadalized/color.py
+++ b/src/hadalized/color.py
@@ -31,9 +31,9 @@ class ColorType(StrEnum):
     Palette ColorField instances.
     """
 
-    info = "ColorInfo"
+    info = auto()
     """Indicates a ColorField should be a full ColorInfo instance."""
-    gamut = "GamutInfo"
+    gamut = auto()
     """Indicates a ColorField should be a GamutInfo instance, typically
     in the gamut defined by a Palette."""
     hex = auto()
@@ -225,7 +225,7 @@ def parse(val: str) -> ColorInfo:
 def extract(
     val: ColorField,
     gamut: str,
-    color_type: ColorType,
+    color_type: str | ColorType,
 ) -> ColorField:
     """Extract fields from a ColorInfo or GamutInfo instance.
 

--- a/src/hadalized/templates/neovim.lua
+++ b/src/hadalized/templates/neovim.lua
@@ -18,6 +18,7 @@
 ---@type Palette
 local palette = {{context.model_dump_lua()}}
 
+
 package.loaded['hadalized'] = nil
 require('hadalized').load({palette = palette})
 

--- a/src/hadalized/web.py
+++ b/src/hadalized/web.py
@@ -1,7 +1,5 @@
 """Named CSS Colors."""
 
-from functools import cache
-
 from hadalized.color import ColorField, ColorMap, parse
 
 
@@ -12,327 +10,159 @@ class WebColors(ColorMap):
     with the values defined lazily in the `get` method.
     """
 
-    pink: ColorField
-    lightpink: ColorField
-    snow: ColorField
-    rosybrown: ColorField
-    crimson: ColorField
-    lightcoral: ColorField
-    indianred: ColorField
-    mistyrose: ColorField
-    brown: ColorField
-    firebrick: ColorField
-    salmon: ColorField
-    maroon: ColorField
-    darkred: ColorField
-    red: ColorField
-    tomato: ColorField
-    orangered: ColorField
-    darksalmon: ColorField
-    coral: ColorField
-    lightsalmon: ColorField
-    sienna: ColorField
-    chocolate: ColorField
-    saddlebrown: ColorField
-    seashell: ColorField
-    darkorange: ColorField
-    sandybrown: ColorField
-    peru: ColorField
-    peachpuff: ColorField
-    linen: ColorField
-    orange: ColorField
-    bisque: ColorField
-    burlywood: ColorField
-    tan: ColorField
-    antiquewhite: ColorField
-    navajowhite: ColorField
-    blanchedalmond: ColorField
-    papayawhip: ColorField
-    moccasin: ColorField
-    darkgoldenrod: ColorField
-    wheat: ColorField
-    oldlace: ColorField
-    goldenrod: ColorField
-    floralwhite: ColorField
-    gold: ColorField
-    cornsilk: ColorField
-    lemonchiffon: ColorField
-    khaki: ColorField
-    palegoldenrod: ColorField
-    darkkhaki: ColorField
-    ivory: ColorField
-    beige: ColorField
-    lightyellow: ColorField
-    lightgoldenrodyellow: ColorField
-    olive: ColorField
-    yellow: ColorField
-    darkolivegreen: ColorField
-    olivedrab: ColorField
-    yellowgreen: ColorField
-    greenyellow: ColorField
-    chartreuse: ColorField
-    lawngreen: ColorField
-    darkgreen: ColorField
-    green: ColorField
-    lime: ColorField
-    limegreen: ColorField
-    forestgreen: ColorField
-    palegreen: ColorField
-    lightgreen: ColorField
-    darkseagreen: ColorField
-    honeydew: ColorField
-    springgreen: ColorField
-    seagreen: ColorField
-    mediumseagreen: ColorField
-    mediumspringgreen: ColorField
-    mintcream: ColorField
-    mediumaquamarine: ColorField
-    aquamarine: ColorField
-    turquoise: ColorField
-    lightseagreen: ColorField
-    mediumturquoise: ColorField
-    darkcyan: ColorField
-    teal: ColorField
-    aqua: ColorField
-    cyan: ColorField
-    darkslategray: ColorField
-    darkslategrey: ColorField
-    paleturquoise: ColorField
-    lightcyan: ColorField
-    darkturquoise: ColorField
-    azure: ColorField
-    cadetblue: ColorField
-    powderblue: ColorField
-    lightblue: ColorField
-    skyblue: ColorField
-    deepskyblue: ColorField
-    lightskyblue: ColorField
-    aliceblue: ColorField
-    steelblue: ColorField
-    slategray: ColorField
-    slategrey: ColorField
-    lightslategray: ColorField
-    lightslategrey: ColorField
-    dodgerblue: ColorField
-    lightsteelblue: ColorField
-    cornflowerblue: ColorField
-    blue: ColorField
-    darkblue: ColorField
-    mediumblue: ColorField
-    navy: ColorField
-    royalblue: ColorField
-    midnightblue: ColorField
-    mediumslateblue: ColorField
-    slateblue: ColorField
-    lavender: ColorField
-    darkslateblue: ColorField
-    ghostwhite: ColorField
-    mediumpurple: ColorField
-    blueviolet: ColorField
-    indigo: ColorField
-    rebeccapurple: ColorField
-    darkviolet: ColorField
-    darkorchid: ColorField
-    mediumorchid: ColorField
-    thistle: ColorField
-    plum: ColorField
-    violet: ColorField
-    fuchsia: ColorField
-    magenta: ColorField
-    darkmagenta: ColorField
-    purple: ColorField
-    orchid: ColorField
-    mediumvioletred: ColorField
-    hotpink: ColorField
-    lavenderblush: ColorField
-    deeppink: ColorField
-    palevioletred: ColorField
+    pink: ColorField = parse("oklch(0.86774 0.07354 7.0855)")
+    lightpink: ColorField = parse("oklch(0.84739 0.08579 9.0865)")
+    snow: ColorField = parse("oklch(0.98894 0.00534 17.247)")
+    rosybrown: ColorField = parse("oklch(0.69274 0.0548 18.565)")
+    crimson: ColorField = parse("oklch(0.57119 0.22194 20.087)")
+    lightcoral: ColorField = parse("oklch(0.72464 0.13774 21.029)")
+    indianred: ColorField = parse("oklch(0.61544 0.14415 22.228)")
+    mistyrose: ColorField = parse("oklch(0.94001 0.03008 25.281)")
+    brown: ColorField = parse("oklch(0.48061 0.15966 25.562)")
+    firebrick: ColorField = parse("oklch(0.49677 0.17969 26.815)")
+    salmon: ColorField = parse("oklch(0.735 0.15151 28.06)")
+    maroon: ColorField = parse("oklch(0.37669 0.15458 29.234)")
+    darkred: ColorField = parse("oklch(0.39986 0.16408 29.234)")
+    red: ColorField = parse("oklch(0.62796 0.25768 29.234)")
+    tomato: ColorField = parse("oklch(0.69622 0.19552 32.321)")
+    orangered: ColorField = parse("oklch(0.6602 0.22936 35.403)")
+    darksalmon: ColorField = parse("oklch(0.75074 0.10818 39.394)")
+    coral: ColorField = parse("oklch(0.73511 0.16799 40.247)")
+    lightsalmon: ColorField = parse("oklch(0.79376 0.12483 42.425)")
+    sienna: ColorField = parse("oklch(0.52648 0.11512 44.604)")
+    chocolate: ColorField = parse("oklch(0.6344 0.15499 50.266)")
+    saddlebrown: ColorField = parse("oklch(0.47078 0.11214 50.845)")
+    seashell: ColorField = parse("oklch(0.97602 0.01425 57.592)")
+    darkorange: ColorField = parse("oklch(0.75054 0.17911 58.283)")
+    sandybrown: ColorField = parse("oklch(0.784 0.12691 59.71)")
+    peru: ColorField = parse("oklch(0.67819 0.12275 62.182)")
+    peachpuff: ColorField = parse("oklch(0.91125 0.06 63.699)")
+    linen: ColorField = parse("oklch(0.96024 0.01715 67.622)")
+    orange: ColorField = parse("oklch(0.79269 0.17103 70.67)")
+    bisque: ColorField = parse("oklch(0.93286 0.05145 71.849)")
+    burlywood: ColorField = parse("oklch(0.80454 0.07786 73.417)")
+    tan: ColorField = parse("oklch(0.78619 0.06382 74.619)")
+    antiquewhite: ColorField = parse("oklch(0.94669 0.03108 75.219)")
+    navajowhite: ColorField = parse("oklch(0.9164 0.07301 77.436)")
+    blanchedalmond: ColorField = parse("oklch(0.94844 0.04493 78.06)")
+    papayawhip: ColorField = parse("oklch(0.95808 0.03826 80.032)")
+    moccasin: ColorField = parse("oklch(0.92962 0.06754 81.379)")
+    darkgoldenrod: ColorField = parse("oklch(0.65207 0.1322 81.572)")
+    wheat: ColorField = parse("oklch(0.90883 0.0615 83.033)")
+    oldlace: ColorField = parse("oklch(0.97234 0.02156 83.264)")
+    goldenrod: ColorField = parse("oklch(0.75157 0.14693 83.988)")
+    floralwhite: ColorField = parse("oklch(0.98623 0.01422 84.583)")
+    gold: ColorField = parse("oklch(0.88677 0.18219 95.33)")
+    cornsilk: ColorField = parse("oklch(0.9773 0.03726 95.439)")
+    lemonchiffon: ColorField = parse("oklch(0.97781 0.05822 102.16)")
+    khaki: ColorField = parse("oklch(0.91349 0.11192 102.83)")
+    palegoldenrod: ColorField = parse("oklch(0.92105 0.07981 103.18)")
+    darkkhaki: ColorField = parse("oklch(0.76747 0.09804 104.51)")
+    ivory: ColorField = parse("oklch(0.99598 0.01962 106.75)")
+    beige: ColorField = parse("oklch(0.96357 0.03278 107)")
+    lightyellow: ColorField = parse("oklch(0.99201 0.04024 107.11)")
+    lightgoldenrodyellow: ColorField = parse("oklch(0.97501 0.05184 107.32)")
+    olive: ColorField = parse("oklch(0.58066 0.12658 109.77)")
+    yellow: ColorField = parse("oklch(0.96798 0.21101 109.77)")
+    darkolivegreen: ColorField = parse("oklch(0.49552 0.0896 126.19)")
+    olivedrab: ColorField = parse("oklch(0.59948 0.13738 126.32)")
+    yellowgreen: ColorField = parse("oklch(0.78485 0.18374 126.64)")
+    greenyellow: ColorField = parse("oklch(0.91305 0.23346 130.02)")
+    chartreuse: ColorField = parse("oklch(0.89026 0.2648 136.01)")
+    lawngreen: ColorField = parse("oklch(0.88175 0.26307 136.17)")
+    darkgreen: ColorField = parse("oklch(0.43602 0.14837 142.5)")
+    green: ColorField = parse("oklch(0.51975 0.17686 142.5)")
+    lime: ColorField = parse("oklch(0.86644 0.29483 142.5)")
+    limegreen: ColorField = parse("oklch(0.74187 0.22865 142.83)")
+    forestgreen: ColorField = parse("oklch(0.5578 0.16878 142.89)")
+    palegreen: ColorField = parse("oklch(0.90354 0.16242 144.09)")
+    lightgreen: ColorField = parse("oklch(0.868 0.1558 144.09)")
+    darkseagreen: ColorField = parse("oklch(0.75086 0.07971 144.73)")
+    honeydew: ColorField = parse("oklch(0.98484 0.02521 145.38)")
+    springgreen: ColorField = parse("oklch(0.87493 0.23526 151.02)")
+    seagreen: ColorField = parse("oklch(0.56853 0.11871 154.95)")
+    mediumseagreen: ColorField = parse("oklch(0.68404 0.14402 155)")
+    mediumspringgreen: ColorField = parse("oklch(0.86681 0.20674 156.9)")
+    mintcream: ColorField = parse("oklch(0.99117 0.01237 164.81)")
+    mediumaquamarine: ColorField = parse("oklch(0.77669 0.10985 168.82)")
+    aquamarine: ColorField = parse("oklch(0.91499 0.13039 168.99)")
+    turquoise: ColorField = parse("oklch(0.82233 0.13074 185.09)")
+    lightseagreen: ColorField = parse("oklch(0.6912 0.11421 188.96)")
+    mediumturquoise: ColorField = parse("oklch(0.7868 0.11622 191.56)")
+    darkcyan: ColorField = parse("oklch(0.57652 0.09841 194.77)")
+    teal: ColorField = parse("oklch(0.54312 0.09271 194.77)")
+    aqua: ColorField = parse("oklch(0.9054 0.15455 194.77)")
+    cyan: ColorField = parse("oklch(0.9054 0.15455 194.77)")
+    darkslategray: ColorField = parse("oklch(0.40296 0.03772 195.76)")
+    darkslategrey: ColorField = parse("oklch(0.40296 0.03772 195.76)")
+    paleturquoise: ColorField = parse("oklch(0.90691 0.06323 196.09)")
+    lightcyan: ColorField = parse("oklch(0.97786 0.03203 196.64)")
+    darkturquoise: ColorField = parse("oklch(0.77193 0.13144 196.64)")
+    azure: ColorField = parse("oklch(0.98895 0.01572 196.9)")
+    cadetblue: ColorField = parse("oklch(0.65768 0.06501 198.3)")
+    powderblue: ColorField = parse("oklch(0.87508 0.0502 205.73)")
+    lightblue: ColorField = parse("oklch(0.85623 0.04894 219.65)")
+    skyblue: ColorField = parse("oklch(0.81482 0.08192 225.75)")
+    deepskyblue: ColorField = parse("oklch(0.75535 0.15342 231.64)")
+    lightskyblue: ColorField = parse("oklch(0.82062 0.09453 236.75)")
+    aliceblue: ColorField = parse("oklch(0.97514 0.01266 244.25)")
+    steelblue: ColorField = parse("oklch(0.588 0.09934 245.74)")
+    slategray: ColorField = parse("oklch(0.5925 0.03092 248.35)")
+    slategrey: ColorField = parse("oklch(0.5925 0.03092 248.35)")
+    lightslategray: ColorField = parse("oklch(0.61902 0.0325 248.35)")
+    lightslategrey: ColorField = parse("oklch(0.61902 0.0325 248.35)")
+    dodgerblue: ColorField = parse("oklch(0.65201 0.19012 253.21)")
+    lightsteelblue: ColorField = parse("oklch(0.81362 0.04281 255.03)")
+    cornflowerblue: ColorField = parse("oklch(0.67462 0.14136 261.34)")
+    blue: ColorField = parse("oklch(0.45201 0.31321 264.05)")
+    darkblue: ColorField = parse("oklch(0.28782 0.19944 264.05)")
+    mediumblue: ColorField = parse("oklch(0.38345 0.26571 264.05)")
+    navy: ColorField = parse("oklch(0.27115 0.18789 264.05)")
+    royalblue: ColorField = parse("oklch(0.55985 0.18823 266.4)")
+    midnightblue: ColorField = parse("oklch(0.28812 0.14363 272.76)")
+    mediumslateblue: ColorField = parse("oklch(0.60447 0.19389 285.5)")
+    slateblue: ColorField = parse("oklch(0.54357 0.17123 285.54)")
+    lavender: ColorField = parse("oklch(0.9309 0.02694 285.86)")
+    darkslateblue: ColorField = parse("oklch(0.41434 0.12484 286.04)")
+    ghostwhite: ColorField = parse("oklch(0.98112 0.00927 286.23)")
+    mediumpurple: ColorField = parse("oklch(0.62518 0.15415 297.27)")
+    blueviolet: ColorField = parse("oklch(0.53376 0.25031 301.37)")
+    indigo: ColorField = parse("oklch(0.33898 0.17927 301.68)")
+    rebeccapurple: ColorField = parse("oklch(0.44027 0.1603 303.37)")
+    darkviolet: ColorField = parse("oklch(0.51491 0.26067 309.81)")
+    darkorchid: ColorField = parse("oklch(0.54111 0.22724 311.51)")
+    mediumorchid: ColorField = parse("oklch(0.62558 0.20244 319.23)")
+    thistle: ColorField = parse("oklch(0.83329 0.04391 325.96)")
+    plum: ColorField = parse("oklch(0.78328 0.10776 326.54)")
+    violet: ColorField = parse("oklch(0.7619 0.18612 327.21)")
+    fuchsia: ColorField = parse("oklch(0.70167 0.32249 328.36)")
+    magenta: ColorField = parse("oklch(0.70167 0.32249 328.36)")
+    darkmagenta: ColorField = parse("oklch(0.4468 0.20535 328.36)")
+    purple: ColorField = parse("oklch(0.42091 0.19345 328.36)")
+    orchid: ColorField = parse("oklch(0.70213 0.18126 328.71)")
+    mediumvioletred: ColorField = parse("oklch(0.55337 0.22165 349.69)")
+    hotpink: ColorField = parse("oklch(0.7283 0.19708 351.99)")
+    lavenderblush: ColorField = parse("oklch(0.96833 0.01741 355.1)")
+    deeppink: ColorField = parse("oklch(0.65493 0.26134 356.94)")
+    palevioletred: ColorField = parse("oklch(0.67397 0.135 359.97)")
     # Zero Hue
-    black: ColorField
-    darkgray: ColorField
-    darkgrey: ColorField
-    dimgray: ColorField
-    dimgrey: ColorField
-    gainsboro: ColorField
-    gray: ColorField
-    grey: ColorField
-    lightgray: ColorField
-    lightgrey: ColorField
-    silver: ColorField
-    white: ColorField
-    whitesmoke: ColorField
-    transparent: ColorField
+    black: ColorField = parse("oklch(0 0 0)")
+    darkgray: ColorField = parse("oklch(0.73481 0 0)")
+    darkgrey: ColorField = parse("oklch(0.73481 0 0)")
+    dimgray: ColorField = parse("oklch(0.52081 0 0)")
+    dimgrey: ColorField = parse("oklch(0.52081 0 0)")
+    gainsboro: ColorField = parse("oklch(0.89449 0 0)")
+    gray: ColorField = parse("oklch(0.59987 0 0)")
+    grey: ColorField = parse("oklch(0.59987 0 0)")
+    lightgray: ColorField = parse("oklch(0.86686 0 0)")
+    lightgrey: ColorField = parse("oklch(0.86686 0 0)")
+    silver: ColorField = parse("oklch(0.8078 0 0)")
+    white: ColorField = parse("oklch(1 0 0)")
+    whitesmoke: ColorField = parse("oklch(0.97015 0 0)")
+    transparent: ColorField = parse("oklch(0 0 0 / 0)")
     # Added
-    offblack: ColorField
-    offdarkgray: ColorField
-    neutralgray: ColorField
-    offlightgray: ColorField
-    offwhite: ColorField
-
-    @cache
-    @staticmethod
-    def get() -> WebColors:
-        """Get a singleton instance.
-
-        Returns:
-            An cached singleton
-
-        """
-        return WebColors(
-            pink=parse("oklch(0.86774 0.07354 7.0855)"),
-            lightpink=parse("oklch(0.84739 0.08579 9.0865)"),
-            snow=parse("oklch(0.98894 0.00534 17.247)"),
-            rosybrown=parse("oklch(0.69274 0.0548 18.565)"),
-            crimson=parse("oklch(0.57119 0.22194 20.087)"),
-            lightcoral=parse("oklch(0.72464 0.13774 21.029)"),
-            indianred=parse("oklch(0.61544 0.14415 22.228)"),
-            mistyrose=parse("oklch(0.94001 0.03008 25.281)"),
-            brown=parse("oklch(0.48061 0.15966 25.562)"),
-            firebrick=parse("oklch(0.49677 0.17969 26.815)"),
-            salmon=parse("oklch(0.735 0.15151 28.06)"),
-            maroon=parse("oklch(0.37669 0.15458 29.234)"),
-            darkred=parse("oklch(0.39986 0.16408 29.234)"),
-            red=parse("oklch(0.62796 0.25768 29.234)"),
-            tomato=parse("oklch(0.69622 0.19552 32.321)"),
-            orangered=parse("oklch(0.6602 0.22936 35.403)"),
-            darksalmon=parse("oklch(0.75074 0.10818 39.394)"),
-            coral=parse("oklch(0.73511 0.16799 40.247)"),
-            lightsalmon=parse("oklch(0.79376 0.12483 42.425)"),
-            sienna=parse("oklch(0.52648 0.11512 44.604)"),
-            chocolate=parse("oklch(0.6344 0.15499 50.266)"),
-            saddlebrown=parse("oklch(0.47078 0.11214 50.845)"),
-            seashell=parse("oklch(0.97602 0.01425 57.592)"),
-            darkorange=parse("oklch(0.75054 0.17911 58.283)"),
-            sandybrown=parse("oklch(0.784 0.12691 59.71)"),
-            peru=parse("oklch(0.67819 0.12275 62.182)"),
-            peachpuff=parse("oklch(0.91125 0.06 63.699)"),
-            linen=parse("oklch(0.96024 0.01715 67.622)"),
-            orange=parse("oklch(0.79269 0.17103 70.67)"),
-            bisque=parse("oklch(0.93286 0.05145 71.849)"),
-            burlywood=parse("oklch(0.80454 0.07786 73.417)"),
-            tan=parse("oklch(0.78619 0.06382 74.619)"),
-            antiquewhite=parse("oklch(0.94669 0.03108 75.219)"),
-            navajowhite=parse("oklch(0.9164 0.07301 77.436)"),
-            blanchedalmond=parse("oklch(0.94844 0.04493 78.06)"),
-            papayawhip=parse("oklch(0.95808 0.03826 80.032)"),
-            moccasin=parse("oklch(0.92962 0.06754 81.379)"),
-            darkgoldenrod=parse("oklch(0.65207 0.1322 81.572)"),
-            wheat=parse("oklch(0.90883 0.0615 83.033)"),
-            oldlace=parse("oklch(0.97234 0.02156 83.264)"),
-            goldenrod=parse("oklch(0.75157 0.14693 83.988)"),
-            floralwhite=parse("oklch(0.98623 0.01422 84.583)"),
-            gold=parse("oklch(0.88677 0.18219 95.33)"),
-            cornsilk=parse("oklch(0.9773 0.03726 95.439)"),
-            lemonchiffon=parse("oklch(0.97781 0.05822 102.16)"),
-            khaki=parse("oklch(0.91349 0.11192 102.83)"),
-            palegoldenrod=parse("oklch(0.92105 0.07981 103.18)"),
-            darkkhaki=parse("oklch(0.76747 0.09804 104.51)"),
-            ivory=parse("oklch(0.99598 0.01962 106.75)"),
-            beige=parse("oklch(0.96357 0.03278 107)"),
-            lightyellow=parse("oklch(0.99201 0.04024 107.11)"),
-            lightgoldenrodyellow=parse("oklch(0.97501 0.05184 107.32)"),
-            olive=parse("oklch(0.58066 0.12658 109.77)"),
-            yellow=parse("oklch(0.96798 0.21101 109.77)"),
-            darkolivegreen=parse("oklch(0.49552 0.0896 126.19)"),
-            olivedrab=parse("oklch(0.59948 0.13738 126.32)"),
-            yellowgreen=parse("oklch(0.78485 0.18374 126.64)"),
-            greenyellow=parse("oklch(0.91305 0.23346 130.02)"),
-            chartreuse=parse("oklch(0.89026 0.2648 136.01)"),
-            lawngreen=parse("oklch(0.88175 0.26307 136.17)"),
-            darkgreen=parse("oklch(0.43602 0.14837 142.5)"),
-            green=parse("oklch(0.51975 0.17686 142.5)"),
-            lime=parse("oklch(0.86644 0.29483 142.5)"),
-            limegreen=parse("oklch(0.74187 0.22865 142.83)"),
-            forestgreen=parse("oklch(0.5578 0.16878 142.89)"),
-            palegreen=parse("oklch(0.90354 0.16242 144.09)"),
-            lightgreen=parse("oklch(0.868 0.1558 144.09)"),
-            darkseagreen=parse("oklch(0.75086 0.07971 144.73)"),
-            honeydew=parse("oklch(0.98484 0.02521 145.38)"),
-            springgreen=parse("oklch(0.87493 0.23526 151.02)"),
-            seagreen=parse("oklch(0.56853 0.11871 154.95)"),
-            mediumseagreen=parse("oklch(0.68404 0.14402 155)"),
-            mediumspringgreen=parse("oklch(0.86681 0.20674 156.9)"),
-            mintcream=parse("oklch(0.99117 0.01237 164.81)"),
-            mediumaquamarine=parse("oklch(0.77669 0.10985 168.82)"),
-            aquamarine=parse("oklch(0.91499 0.13039 168.99)"),
-            turquoise=parse("oklch(0.82233 0.13074 185.09)"),
-            lightseagreen=parse("oklch(0.6912 0.11421 188.96)"),
-            mediumturquoise=parse("oklch(0.7868 0.11622 191.56)"),
-            darkcyan=parse("oklch(0.57652 0.09841 194.77)"),
-            teal=parse("oklch(0.54312 0.09271 194.77)"),
-            aqua=parse("oklch(0.9054 0.15455 194.77)"),
-            cyan=parse("oklch(0.9054 0.15455 194.77)"),
-            darkslategray=parse("oklch(0.40296 0.03772 195.76)"),
-            darkslategrey=parse("oklch(0.40296 0.03772 195.76)"),
-            paleturquoise=parse("oklch(0.90691 0.06323 196.09)"),
-            lightcyan=parse("oklch(0.97786 0.03203 196.64)"),
-            darkturquoise=parse("oklch(0.77193 0.13144 196.64)"),
-            azure=parse("oklch(0.98895 0.01572 196.9)"),
-            cadetblue=parse("oklch(0.65768 0.06501 198.3)"),
-            powderblue=parse("oklch(0.87508 0.0502 205.73)"),
-            lightblue=parse("oklch(0.85623 0.04894 219.65)"),
-            skyblue=parse("oklch(0.81482 0.08192 225.75)"),
-            deepskyblue=parse("oklch(0.75535 0.15342 231.64)"),
-            lightskyblue=parse("oklch(0.82062 0.09453 236.75)"),
-            aliceblue=parse("oklch(0.97514 0.01266 244.25)"),
-            steelblue=parse("oklch(0.588 0.09934 245.74)"),
-            slategray=parse("oklch(0.5925 0.03092 248.35)"),
-            slategrey=parse("oklch(0.5925 0.03092 248.35)"),
-            lightslategray=parse("oklch(0.61902 0.0325 248.35)"),
-            lightslategrey=parse("oklch(0.61902 0.0325 248.35)"),
-            dodgerblue=parse("oklch(0.65201 0.19012 253.21)"),
-            lightsteelblue=parse("oklch(0.81362 0.04281 255.03)"),
-            cornflowerblue=parse("oklch(0.67462 0.14136 261.34)"),
-            blue=parse("oklch(0.45201 0.31321 264.05)"),
-            darkblue=parse("oklch(0.28782 0.19944 264.05)"),
-            mediumblue=parse("oklch(0.38345 0.26571 264.05)"),
-            navy=parse("oklch(0.27115 0.18789 264.05)"),
-            royalblue=parse("oklch(0.55985 0.18823 266.4)"),
-            midnightblue=parse("oklch(0.28812 0.14363 272.76)"),
-            mediumslateblue=parse("oklch(0.60447 0.19389 285.5)"),
-            slateblue=parse("oklch(0.54357 0.17123 285.54)"),
-            lavender=parse("oklch(0.9309 0.02694 285.86)"),
-            darkslateblue=parse("oklch(0.41434 0.12484 286.04)"),
-            ghostwhite=parse("oklch(0.98112 0.00927 286.23)"),
-            mediumpurple=parse("oklch(0.62518 0.15415 297.27)"),
-            blueviolet=parse("oklch(0.53376 0.25031 301.37)"),
-            indigo=parse("oklch(0.33898 0.17927 301.68)"),
-            rebeccapurple=parse("oklch(0.44027 0.1603 303.37)"),
-            darkviolet=parse("oklch(0.51491 0.26067 309.81)"),
-            darkorchid=parse("oklch(0.54111 0.22724 311.51)"),
-            mediumorchid=parse("oklch(0.62558 0.20244 319.23)"),
-            thistle=parse("oklch(0.83329 0.04391 325.96)"),
-            plum=parse("oklch(0.78328 0.10776 326.54)"),
-            violet=parse("oklch(0.7619 0.18612 327.21)"),
-            fuchsia=parse("oklch(0.70167 0.32249 328.36)"),
-            magenta=parse("oklch(0.70167 0.32249 328.36)"),
-            darkmagenta=parse("oklch(0.4468 0.20535 328.36)"),
-            purple=parse("oklch(0.42091 0.19345 328.36)"),
-            orchid=parse("oklch(0.70213 0.18126 328.71)"),
-            mediumvioletred=parse("oklch(0.55337 0.22165 349.69)"),
-            hotpink=parse("oklch(0.7283 0.19708 351.99)"),
-            lavenderblush=parse("oklch(0.96833 0.01741 355.1)"),
-            deeppink=parse("oklch(0.65493 0.26134 356.94)"),
-            palevioletred=parse("oklch(0.67397 0.135 359.97)"),
-            # Zero Hue
-            black=parse("oklch(0 0 0)"),
-            darkgray=parse("oklch(0.73481 0 0)"),
-            darkgrey=parse("oklch(0.73481 0 0)"),
-            dimgray=parse("oklch(0.52081 0 0)"),
-            dimgrey=parse("oklch(0.52081 0 0)"),
-            gainsboro=parse("oklch(0.89449 0 0)"),
-            gray=parse("oklch(0.59987 0 0)"),
-            grey=parse("oklch(0.59987 0 0)"),
-            lightgray=parse("oklch(0.86686 0 0)"),
-            lightgrey=parse("oklch(0.86686 0 0)"),
-            silver=parse("oklch(0.8078 0 0)"),
-            white=parse("oklch(1 0 0)"),
-            whitesmoke=parse("oklch(0.97015 0 0)"),
-            transparent=parse("oklch(0 0 0 / 0)"),
-            # Added
-            offblack=parse("oklch(0.10 0.01 220)"),
-            offdarkgray=parse("oklch(0.30 0.01 220)"),
-            neutralgray=parse("oklch(0.50 0.01 220)"),
-            offlightgray=parse("oklch(0.70 0.01 220)"),
-            offwhite=parse("oklch(0.995 0.01 220)"),
-        )
+    offblack: ColorField = parse("oklch(0.10 0.01 220)")
+    offdarkgray: ColorField = parse("oklch(0.30 0.01 220)")
+    neutralgray: ColorField = parse("oklch(0.50 0.01 220)")
+    offlightgray: ColorField = parse("oklch(0.70 0.01 220)")
+    offwhite: ColorField = parse("oklch(0.995 0.01 220)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from hadalized.config import Config
 
 if TYPE_CHECKING:
     from hadalized.palette import Palette
+    from hadalized.config import BuildConfig
 
 _config = Config()
 
@@ -13,14 +14,18 @@ _config = Config()
 @pytest.fixture
 def config(tmp_path) -> Config:
     return Config(
-        build_dir=tmp_path,
-        cache_dir=None,
-        copy_dir=tmp_path / "copies",
-        copy_files=True,
-        template_fs_dir=Path(__file__).parent,
+        build_dir=tmp_path / "build",
+        cache_dir=tmp_path / "cache",
+        template_dir=Path(__file__).parent,
+        verbose=True,
     )
 
 
 @pytest.fixture
 def palette() -> Palette:
     return _config.palettes["hadalized"]
+
+
+@pytest.fixture
+def build_config() -> BuildConfig:
+    return _config.builds["neovim"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,7 @@ def test_add(tmp_path):
     with Cache(cache_dir=tmp_path) as cache:
         path = tmp_path / "test.txt"
         cache.add(path, "123")
-        assert cache.get_hash(path) == "123"
+        assert cache.get(path) == "123"
 
 
 def test_delete(tmp_path):
@@ -15,7 +15,7 @@ def test_delete(tmp_path):
         path = tmp_path / "test.txt"
         cache.add(path, "123")
         cache.delete(path)
-        assert cache.get_hash(path) is None
+        assert cache.get(path) is None
 
 
 def test_clear(tmp_path):
@@ -27,13 +27,13 @@ def test_clear(tmp_path):
 
 
 def test_add_in_memory():
-    with Cache(cache_dir=None) as cache:
+    with Cache(in_memory=True) as cache:
         path = "test.txt"
         cache.add(path, "123")
-        assert cache.get_hash(path) == "123"
+        assert cache.get(path) == "123"
 
 
 def test_exit_with_error():
     with pytest.raises(ValueError):
-        with Cache(None):
+        with Cache(in_memory=True):
             raise ValueError("bomb")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from hadalized.cli import main as m
+
+
+def test_build_single_app(tmp_path, config):
+    m.build(app=["neovim"], out=tmp_path, prefix=True, config=config)
+    assert (config.build_dir / "neovim" / "hadalized.lua").exists()
+    assert (tmp_path / "neovim" / "hadalized.lua").exists()
+
+
+def test_cache_list():
+    m.cache_list()

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -3,24 +3,24 @@ from hadalized.palette import Palette
 
 
 def test_palette_to(palette: Palette):
-    val = palette.hex()
+    val = palette.to("hex")
     leaf = val.hue.red
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
     assert leaf.startswith("#")
 
-    val = palette.css()
+    val = palette.to("css")
     leaf = val.hue.red
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
 
-    val = palette.oklch()
+    val = palette.to("oklch")
     leaf = val.hue.red
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
     assert leaf.startswith("oklch")
 
-    val = palette.gamut_info()
+    val = palette.to("gamut")
     leaf = val.hue.red
     assert isinstance(val, Palette)
     assert isinstance(leaf, GamutInfo)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -11,10 +11,10 @@ def test_template_is_hashable():
 
 
 def test_template_load_from_specified_dir(config: Config):
-    template = Template("template.txt", fs_dir=config.template_fs_dir)
+    template = Template("template.txt", template_dir=config.template_dir)
     assert template._template
 
 
 def test_template_load_from_specified_dir_fail(config: Config):
     with pytest.raises(TemplateNotFound):
-        Template("does-not-exist.txt", fs_dir=config.template_fs_dir)
+        Template("does-not-exist.txt", template_dir=config.template_dir)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,5 @@
+from hadalized.web import WebColors
+
+
+def test_init():
+    assert WebColors()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,28 +1,26 @@
 import pytest
 
 from hadalized.config import Config
-from hadalized.writer import ThemeWriter, run
+from hadalized.writer import ThemeWriter
 
 
-def test_theme_writer_run(config: Config):
-    """Tests the main ThemeWriter.run"""
+def test_theme_writer_run_uses_cache(config: Config, build_config):
+    config = config.replace(builds={"neovim": build_config})
     with ThemeWriter(config) as writer:
         written = writer.run()
         assert written
-        assert (config.build_dir / "neovim" / "hadalized.lua").exists()
-        assert (config.build_dir / "wezterm" / "hadalized.toml").exists()
-        assert (config.build_dir / "starship" / "starship.toml").exists()
-        # Check now that the in memory cache is checks result in no new builds.
         written = writer.run()
         assert written == []
 
 
-def test_run(config: Config):
-    """Tests the main ThemeWriter.run"""
-    run(config)
+def test_build_with_copy(config: Config, build_config):
+    with ThemeWriter(config) as writer:
+        output_dir = config.build_dir / "copies"
+        writer.build(build_config, output_dir=output_dir)
+        assert (output_dir / "hadalized.lua").exists()
 
 
-def test_writer_exist_with_exception(config: Config):
+def test_writer_exits_with_exception(config: Config):
     with pytest.raises(ValueError):
         with ThemeWriter(config):
             raise ValueError("bomb")

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
 name = "coloraide"
 version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -74,12 +83,45 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/663f3285c1ac0e5d0854bd9db2c87caa6fa3d1a063185e3394a6cdca9151/cyclopts-4.5.0.tar.gz", hash = "sha256:717ac4235548b58d500baf7e688aa4d024caf0ee68f61a012ffd5e29db3099f9", size = 161980, upload-time = "2026-01-16T02:07:16.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a3/2e00fececc34a99ae3a5d5702a5dd29c5371e4ed016647301a2b9bcc1976/cyclopts-4.5.0-py3-none-any.whl", hash = "sha256:305b9aa90a9cd0916f0a450b43e50ad5df9c252680731a0719edfb9b20381bf5", size = 199772, upload-time = "2026-01-16T02:07:14.707Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -93,10 +135,11 @@ wheels = [
 
 [[package]]
 name = "hadalized"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },
+    { name = "cyclopts" },
     { name = "jinja2" },
     { name = "loguru" },
     { name = "luadata" },
@@ -116,6 +159,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coloraide", specifier = ">=6.2" },
+    { name = "cyclopts", specifier = ">=4.5.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "luadata", specifier = ">=1.0.5" },
@@ -221,6 +265,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +316,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -422,6 +487,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Use `cyclopts` to drive CLI.
- Introduce the `Grayscale` color map with defaults.
- Add `Palette.gs` node to reference basic grayscale colors by name.
- Remove `Palette.web` node.
- Simplify some public methods to accept string variants for StrEnum instances.