### PR TITLE
Avoid unexpected palette conversions.

### DIFF
--- a/src/hadalized/palette.py
+++ b/src/hadalized/palette.py
@@ -13,8 +13,8 @@ from hadalized.color import (
     ColorFieldHandler,
     ColorFieldType,
     ColorMap,
+    Extractor,
     Parser,
-    extractor,
 )
 
 
@@ -140,21 +140,23 @@ class Palette(PaletteColors, PaletteMeta):
     def to(self, color_type: ColorFieldType | str) -> Self:
         """Entry point for the `map` method that accepts a directive.
 
-        Raises:
-            TypeError: If this method is called on an unparsed instance.
+        When called on an unparsed instance, a new parsed instance is created
+        and acted on.
+
+        Usage:
+            palette = palette.to("hex")
 
         Returns:
             A new Palette instance with the handler applied to each
             field that contains a ColorMap instance.
 
         """
-        if not self._is_parsed:
-            raise TypeError(f"Palette {self.name} is not parsed.")
-        if color_type == ColorFieldType.identity:
-            pal = self
-        elif (pal := self._cache.get(color_type)) is None:
-            pal = self.map(extractor(color_type))
-            self._cache[color_type] = pal
+        inst = self if self._is_parsed else self.parse()
+        if color_type == ColorFieldType.info:
+            return inst
+        if (pal := inst._cache.get(color_type)) is None:
+            pal = self.map(Extractor(color_type))
+            inst._cache[color_type] = pal
         return pal
 
     def parse(self, gamut: str | None = None) -> Self:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 import pytest
 
-from hadalized.config import Config
+from hadalized.config import default_palettes, Config
 
 if TYPE_CHECKING:
     from hadalized.palette import Palette
@@ -24,6 +24,11 @@ def config(tmp_path) -> Config:
 @pytest.fixture
 def palette() -> Palette:
     return _config.get_palette("dark").parse()
+
+
+@pytest.fixture
+def raw_palette() -> Palette:
+    return default_palettes()["hadalized"]
 
 
 @pytest.fixture

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -1,24 +1,45 @@
+import pytest
+
+from hadalized.color import ColorFieldType
 from hadalized.palette import Palette
 
 
 def test_palette_parse_is_idempotent(palette: Palette):
-    assert palette.parse().parse() == palette.parse()
+    assert palette.parse().parse() is palette.parse()
 
 
-def test_palette_to(palette: Palette):
-    val = palette.to("hex")
+def test_palette_to_chained_error(palette: Palette):
+    with pytest.raises(TypeError):
+        palette.to("hex").to("hex")
+
+
+def test_palette_to_info(raw_palette: Palette):
+    parsed = raw_palette.to(ColorFieldType.info)
+    assert parsed._is_parsed
+    assert parsed.to(ColorFieldType.info) is parsed
+
+
+def test_palette_to_hex(palette: Palette):
+    val = palette.to(ColorFieldType.hex)
     leaf = val.hue.red
+    assert val.hue.field_type == ColorFieldType.hex
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
     assert leaf.startswith("#")
 
+
+def test_palette_to_css(palette: Palette):
     val = palette.to("css")
     leaf = val.hue.red
+    assert val.hue.field_type == ColorFieldType.css
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
 
+
+def test_palette_to_oklch(palette: Palette):
     val = palette.to("oklch")
     leaf = val.hue.red
+    assert val.hue.field_type == ColorFieldType.oklch
     assert isinstance(val, Palette)
     assert isinstance(leaf, str)
     assert leaf.startswith("oklch")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,10 +2,27 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from hadalized.color import parse
+from hadalized.color import Parser, parse
 
 if TYPE_CHECKING:
     pass
+
+
+def test_parse_oklch():
+    parser = Parser("srgb")
+    val = "oklch(0.5 0.1 25)"
+    info = parser(val)
+    assert info.oklch == val
+    assert parser(info) is info
+
+
+def test_parse_rgb():
+    assert parse("rgb(0.5 0.5 0.5)")
+
+
+def test_parse_fail():
+    with pytest.raises(ValueError):
+        parse("bad color")
 
 
 @pytest.mark.parametrize(
@@ -20,3 +37,10 @@ def test_in_gamut(val: str, gamut: str, in_gamut: bool):
     assert color.is_in_gamut is in_gamut
     if not in_gamut:
         assert color.oklch != color.raw_oklch
+
+
+def test_max_oklch():
+    parser = Parser("srgb")
+    val = "oklch(0.5 0.5 25)"
+    color = parser(val).color().convert("srgb")
+    assert parser._max_oklch_chroma(color) < 0.5

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,7 +1,17 @@
 import pytest
 
-from hadalized.config import Config
+from hadalized.config import Config, BuildConfig, ContextType
 from hadalized.writer import ThemeWriter
+
+
+def test_writer_full_context(config: Config):
+    build = BuildConfig(
+        name="test",
+        template="template.txt",
+        context_type=ContextType.full,
+    )
+    with ThemeWriter(config) as writer:
+        writer.build(build)
 
 
 def test_theme_writer_run_uses_cache(config: Config, build_config):


### PR DESCRIPTION
- Add `Extractor` class that replaces partials.
- Chained extractions raise TypeErrors.
- The `Palette.to` method will first parse.
- Chaining `Palette.to` will result in a TypeError.
- Increase test coverage.