### PR TITLE
Ensure more consistent caching.

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,8 @@ check:
 bump part:
     uv version --bump {{part}}
 
+# ver:
+#     VERSION=$(hdl --version) && echo "version is $VERSION"
 
 # Pushing a tag of the form v* kicks off the publish github workflow.
 publish version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hadalized"
-version = "0.5.2"
+version = "0.5.3"
 description = "Hadalized color theme builder."
 readme = "README.md"
 authors = [

--- a/src/hadalized/base.py
+++ b/src/hadalized/base.py
@@ -73,6 +73,15 @@ class BaseNode(BaseSettings):
         """
         return self.model_validate(self.model_dump() | kwargs)
 
+    def encode(self) -> bytes:
+        """Encode the data structure json dump.
+
+        Returns:
+            A byte encoding of the model to pass into built hash proxy.
+
+        """
+        return self.model_dump_json().encode()
+
     def __getitem__(self, key: str):
         """Provide dict-like lookup for all models.
 

--- a/src/hadalized/config.py
+++ b/src/hadalized/config.py
@@ -344,6 +344,16 @@ class Config(Options):
         """
         return self.replace(palettes={k: v.parse() for k, v in self.palettes.items()})
 
+    def encode(self) -> bytes:
+        """Encode the data structure json dump.
+
+        Returns:
+            A byte encoding of the model to pass into built hash proxy.
+
+        """
+        include = {"palettes", "terminal"}
+        return self.model_dump_json(include=include).encode()
+
     def __hash__(self) -> int:
         """Hash of the main config contents, excluding runtime options.
 
@@ -352,7 +362,7 @@ class Config(Options):
 
         """
         if self._hash is None:
-            include = {"palettes", "build", "terminal"}
+            include = {"palettes", "terminal"}
             self._hash = hash(self.model_dump_json(include=include))
         return self._hash
 

--- a/src/hadalized/options.py
+++ b/src/hadalized/options.py
@@ -82,7 +82,7 @@ class Options(BaseNode):
     items must include a key or alias in the ``Config.palettes`` definitions.
     If not specified, all defined palettes will be utilized.
     """
-    prefix: Annotated[bool, Parameter(negative="")] = False
+    prefix: Annotated[bool, Parameter()] = False
     """When set in conjunction with an output directory, built themes will
     be placed in a subdirectory determined by built theme file's parent
     directory. Typically this is just the applicate name, e.g., 'neovim'."""

--- a/src/hadalized/writer.py
+++ b/src/hadalized/writer.py
@@ -34,7 +34,7 @@ def _encode(val: Template | BaseNode) -> bytes:
             with suppress(FileNotFoundError):
                 data = Path(fname).read_bytes()
     else:
-        data = val.model_dump_json().encode()
+        data = val.encode()
 
     return data
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,6 @@ from hadalized.config import Options
 @pytest.fixture
 def realopts(tmp_path: Path) -> Options:
     return Options(
-        # include_build=["neovim"],
         include_palettes=["hadalized"],
         prefix=True,
         state_dir=tmp_path / "state",
@@ -22,7 +21,6 @@ def realopts(tmp_path: Path) -> Options:
 @pytest.fixture
 def dryopts(tmp_path: Path) -> Options:
     return Options(
-        # include_build=["neovim"],
         include_palettes=["hadalized"],
         prefix=True,
         state_dir=tmp_path / "state",
@@ -47,9 +45,18 @@ def test_build_single_app_no_copy(realopts: Options):
     assert (opt.build_dir / "starship" / "starship.toml").exists()
 
 
+def test_build_all(realopts: Options):
+    opt = realopts
+    assert opt.output_dir is not None
+    m.build(opt=opt)
+    assert (opt.build_dir / "neovim" / "hadalized.lua").exists()
+    assert (opt.output_dir / "neovim" / "hadalized.lua").exists()
+
+
 def test_build_single_app_dry(dryopts: Options):
     opt = dryopts
     m.build(name="neovim", opt=opt)
+    assert (opt.build_dir / "neovim" / "hadalized.lua").exists() is False
 
 
 def test_cache_list():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,9 @@ def test_opts_properties():
     opts = Options(no_config=True)
     assert opts.use_cache is True
     assert opts.use_templates is False
+
+
+def test_encode_ignores_opts():
+    conf1 = Config()
+    conf2 = Config(verbose=True)
+    assert conf1.encode() == conf2.encode()

--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "hadalized"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },


### PR DESCRIPTION
Only pass a subset of `Config` when encoding to compute built file proxy hashes.

Some theme templates, such as starship, assume every defined palette is passed in. We pass a `Config` instance as the context in such cases. To compute a hash of the would-be generated file, we need to distinguish between what are renderables and what constitutes user options.