### PR TITLE
Simplify ColorInfo Object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hadalized"
-version = "0.5.4"
+version = "0.6.0"
 description = "Hadalized color theme builder."
 readme = "README.md"
 authors = [

--- a/src/hadalized/color.py
+++ b/src/hadalized/color.py
@@ -112,19 +112,11 @@ class ColorInfo(BaseNode):
     """
 
     raw: str = Field(examples=["oklch(0.6 0.2 25)", "#010203"])
-    # parsed: ColorBase = Field(exclude=True)
     """Parseable color definition, e.g., a css value."""
-    gamut: str = Field(
-        default=ColorSpace.srgb,
-        examples=["srgb", "display-p3"],
-    )
-    """Target gamut to fit the raw color definition to."""
-    raw_oklch: ColorFieldStr
-    """Raw input in the oklch colorspace."""
     oklch: ColorFieldStr
-    """OKLCH value fit to the specified `gamut`."""
+    """OKLCH css value fit to the specified gamut defined by `css`."""
     css: ColorFieldStr
-    """CSS value in the gamut."""
+    """CSS value in the gamut. Encodes the underlying gamut."""
     hex: ColorFieldStr
     """24 or 32-bit hex representation for RGB gamuts."""
     is_in_gamut: bool
@@ -207,8 +199,6 @@ class Parser:
 
         inst = ColorInfo(
             raw=val,
-            raw_oklch=raw_oklch.to_string(),
-            gamut=self.gamut,
             oklch=oklch_fit.to_string(),
             css=color.to_string(),
             hex=self._to_hex(color),

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -9,9 +9,7 @@ def test_color_info_color_method():
     color = Color(raw)
     val = ColorInfo(
         raw=raw,
-        gamut="srgb",
         oklch="",
-        raw_oklch="",
         hex="",
         css="",
         is_in_gamut=True,
@@ -23,9 +21,7 @@ def test_color_info_color_method():
 def test_color_info_color_method_raises_error():
     val = ColorInfo(
         raw="bad color",
-        gamut="",
         oklch="",
-        raw_oklch="",
         hex="",
         css="",
         is_in_gamut=True,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,8 +30,6 @@ def test_parse_fail():
 def test_in_gamut(val: str, gamut: str, in_gamut: bool):
     color = parse(val, gamut=gamut)
     assert color.is_in_gamut is in_gamut
-    if not in_gamut:
-        assert color.oklch != color.raw_oklch
 
 
 def test_max_oklch():

--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "hadalized"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },


### PR DESCRIPTION
Remove the `ColorInfo` fields `raw_oklch` and `gamut`. The former is largely unused, while the latter is encoded in the `css` field.